### PR TITLE
Django 1.2 compatibility fix

### DIFF
--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -11,7 +11,11 @@ from django.conf import settings
 from django.contrib.admin import widgets as admin_widgets
 from django.core.urlresolvers import reverse
 from django.forms.widgets import flatatt
-from django.forms.util import smart_unicode
+#for compatibility import with Django 1.2
+try:
+    from django.forms.util import smart_unicode
+except ImportError:
+    from django.utils.encoding import smart_unicode
 from django.utils.html import escape
 from django.utils import simplejson
 from django.utils.datastructures import SortedDict


### PR DESCRIPTION
Changed an import, but still works with pre-1.2 Django too. (Tries the old import first, then does the 1.2-style import if that failed). Thanks.
